### PR TITLE
platform/mikro-e/platform-init.c: Fix ca8210 macro

### DIFF
--- a/platform/mikro-e/platform-init.c
+++ b/platform/mikro-e/platform-init.c
@@ -90,7 +90,7 @@ platform_init()
     TRISDSET = _TRISD_TRISD5_MASK;
     INT1R = 0b0110;
 
-  #elif __USE_CA8210
+  #elif __USE_CA8210__
 
     /* INT1 for CA8210 NIRQ: RD1 */
     TRISDSET = _TRISD_TRISD1_MASK;


### PR DESCRIPTION
Fix typo in use of ca8210 define.