### PR TITLE
platform: mikro-e: Start watchdog before starting autostart_processes

### DIFF
--- a/platform/mikro-e/contiki-mikro-e-main.c
+++ b/platform/mikro-e/contiki-mikro-e-main.c
@@ -93,8 +93,9 @@ main(int argc, char **argv)
 #endif
   serial_line_init();
 
-  autostart_start(autostart_processes);
   watchdog_start();
+
+  autostart_start(autostart_processes);
 
   while(1) {
     do {


### PR DESCRIPTION
This connects to CreatorDev/contiki#29.

The autostart_start function was executing processes before the
watchdog was started. This means that until processes were yield,
no watchdog was enabled.

This commit ensures that watchdog_start is called before calling
autostart_start.

Signed-off-by: Francois Berder <francois.berder@imgtec.com>