### PR TITLE
platform: mikro-e: Remove undef DEBUG macro in radio conf headers

### DIFF
--- a/platform/mikro-e/ca8210-conf.h
+++ b/platform/mikro-e/ca8210-conf.h
@@ -36,9 +36,8 @@
 #ifndef CA8210_CONF_H
 #define CA8210_CONF_H
 
-#undef DEBUG /* Conflict with a macro named DEBUG defined in compiler */
+
 #include <p32xxxx.h>
-#undef DEBUG
 
 #include <pic32_gpio.h>
 #include <pic32_irq.h>

--- a/platform/mikro-e/cc2520-conf.h
+++ b/platform/mikro-e/cc2520-conf.h
@@ -32,9 +32,7 @@
 #ifndef __CC2520_CONF_H__
 #define __CC2520_CONF_H__
 
-#undef DEBUG /* Conflict with a macro named DEBUG defined in compiler */
 #include <p32xxxx.h>
-#undef DEBUG
 
 #include <pic32_gpio.h>
 

--- a/platform/mikro-e/contiki-conf.h
+++ b/platform/mikro-e/contiki-conf.h
@@ -36,11 +36,6 @@
 #define DEBUG_HIGHER_LEVELS 0
 
 #include <inttypes.h>
-#ifdef __USE_CC2520__
-  #include "cc2520-conf.h"
-#elif  __USE_CA8210__
-  #include "ca8210-conf.h"
-#endif
 
 /* Include project config file if defined in the project Makefile */
 #ifdef PROJECT_CONF_H


### PR DESCRIPTION
This connects to #15 .

The p32xxxx.h header was defining the DEBUG symbol which conflicts
with the debug macro defined in other Contiki files to print
debug messages.

This commits removes ca8210-conf.h and cc2520-conf.h from contiki-conf
header since these headers are specific to the radio and should be
included only by the radio implementation.

Signed-off-by: Francois Berder <francois.berder@imgtec.com>