### PR TITLE
cpu/pic32: Configure prefetch cache

### DIFF
--- a/cpu/pic32/pic32.c
+++ b/cpu/pic32/pic32.c
@@ -56,12 +56,16 @@
  * the 3xx and 4xx families of the pic32mx.
  */
 
+#include <pic32_clock.h>
 #include <pic32_irq.h>
 
 #include <p32xxxx.h>
 #include <stdint.h>
 
 #include <dev/leds.h>
+
+/* The flash can be accessed at up to 30Mhz */
+#define FLASH_CLOCK_SPEED       (30000000)
 
 /* General Excepiton Handler: overrides the default handler */
 static enum {
@@ -88,7 +92,7 @@ static unsigned int cp0_exception_epc;   /* CP0: Exception Program Counter */
 void
 pic32_init(void)
 {
-  unsigned long int r;
+  unsigned long int r, wait_state_count;
 
   ASM_DIS_INT;
 
@@ -110,6 +114,19 @@ pic32_init(void)
   OSCCONCLR = 1 << _OSCCON_SLPEN_POSITION;
 
   SYSKEY = 0;
+
+  /*
+   * Compute minimum number of wait state required such that
+   *      (ws_count + 1) * FLASH_CLOCK_SPEED >= SYSCLK
+   */
+  wait_state_count = 0;
+  while(pic32_clock_get_system_clock() > FLASH_CLOCK_SPEED * (wait_state_count + 1)) {
+    ++wait_state_count;
+  }
+
+  CHECON = (0b01 << _CHECON_DCSZ_POSITION)    /* Data cache size of 1 line */
+    | (0b11 << _CHECON_PREFEN_POSITION)  /* Enable predictive prefetch for all regions */
+    | (wait_state_count & _CHECON_PFMWS_MASK);
 
   ASM_EN_INT;
 }


### PR DESCRIPTION
This connects to #32 .

The number of wait states to access program memory is by
default 7. This number can be reduced to only 2 if the system
clock is at 80MHz.
This commit computes the minimum number of wait states required
and enables predictive prefetching for all regions. It also
reserves one cache line for data.

Signed-off-by: Francois Berder <francois.berder@imgtec.com>