### PR TITLE
platform: mikro-e: Allow for overriding of UART_DEBUG_BAUDRATE

### DIFF
--- a/platform/mikro-e/contiki-mikro-e-main.c
+++ b/platform/mikro-e/contiki-mikro-e-main.c
@@ -49,7 +49,9 @@
 
 void (*interrupt_isr)(void) = NULL;
 
+#ifndef UART_DEBUG_BAUDRATE
 #define UART_DEBUG_BAUDRATE 115200
+#endif
 
 #ifdef MOTION_CLICK
 SENSORS(&button_sensor, &button_sensor2, &motion_sensor);


### PR DESCRIPTION
This closes #66 