### PR TITLE
Jenkinsfile: enable minimum heap size for generic examples

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,8 @@ node('docker && imgtec') {
             for (item in examples) {
                 try {
                     sh "cd examples/${item} && make -j8 TARGET=mikro-e CHANNEL=${params.CHANNEL} \
-                    PAN_ID=${params.PAN_ID} USE_SERIAL_PADS=${params.PADS}"
+                    PAN_ID=${params.PAN_ID} USE_SERIAL_PADS=${params.PADS} \
+                    LDFLAGS=-Wl,--defsym,_min_heap_size=32000"
                     sh "cd examples/${item} && xc32-bin2hex *.mikro-e && mv *.hex ${WORKSPACE}/"
                 } catch(exc) {
                     echo "Caught: ${exc}"


### PR DESCRIPTION
The default examples lack the minimum heap size linker flag that all mikro-e apps have, this can cause
a build failure due to the linker needing a heap while none is provided.