### PR TITLE
platform/mikro-e: define minimum heap size

### DIFF
--- a/platform/mikro-e/Makefile.mikro-e
+++ b/platform/mikro-e/Makefile.mikro-e
@@ -55,6 +55,9 @@ PAN_ID?=0xabcd
 CFLAGS += -DRF_CHANNEL=$(CHANNEL)
 CFLAGS += -DIEEE802154_CONF_PANID=$(PAN_ID)
 
+HEAP_SIZE?=32768
+LDFLAGS += -Wl,--defsym,_min_heap_size=$(HEAP_SIZE)
+
 include $(CONTIKI)/cpu/pic32/Makefile.pic32
 
 


### PR DESCRIPTION
Any applications or examples that are built and require the heap will fail due to no
minimum heap size being specified, this commit sets it to at least 32 KiB.

This closes #95 