### PR TITLE
cpu: pic32: Fix use of timer 4/5 for rtimer

### DIFF
--- a/cpu/pic32/rtimer-arch.c
+++ b/cpu/pic32/rtimer-arch.c
@@ -107,6 +107,6 @@ rtimer_arch_schedule(rtimer_clock_t t)
 }
 /*---------------------------------------------------------------------------*/
 
-TIMER_INTERRUPT(3, rtimer_callback);
+TIMER_INTERRUPT(5, rtimer_callback);
 
 /** @} */


### PR DESCRIPTION
The rtimer is configured to use timer 4/5 but the wrong timer number is passed to
TIMER_INTERRUPT, preventing rtimer to work.
This patch correctly passes timer number 5 to the TIMER_INTERRUPT macro.

Signed-off-by: Salvatore De Dominicis <salvatore.dedominicis@gmail.com>